### PR TITLE
Update gdk-pixbuf loaders via post-link

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
   timeoutInMinutes: 360
   strategy:
     maxParallel: 8
@@ -73,4 +73,4 @@ jobs:
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -11,7 +11,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge,c4aarch64,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
 matrix:
   include:
     - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
-      os: linux-ppc64le
+      os: linux
+      arch: ppc64le
 
 script:
   - export CI=travis

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Current build status
 <table><tr>
     <td>Travis</td>
     <td>
-      <a href="https://travis-ci.org/conda-forge/librsvg-feedstock">
-        <img alt="macOS" src="https://img.shields.io/travis/conda-forge/librsvg-feedstock/master.svg?label=macOS">
+      <a href="https://travis-ci.com/conda-forge/librsvg-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/librsvg-feedstock/master.svg?label=macOS">
       </a>
     </td>
   </tr><tr>
@@ -127,7 +127,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     # Looks good but no new info after 2.43 so keeping it x.x for safety.

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,2 @@
+# The gdk-pixbuf post-link function updates the loaders
+${PREFIX}/bin/.gdk-pixbuf-post-link.sh

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,0 +1,7 @@
+# Since librsvg is being removed, we want it to be removed from loaders.cache.
+# But since this is a PRE-unlink script, the loader is still present.
+# Remove it now so we can update loaders.cache correctly.
+rm ${PREFIX}/lib/gdk-pixbuf-2.0/*/loaders/libpixbufloader-svg.so
+
+# The gdk-pixbuf post-link function updates the loaders
+${PREFIX}/bin/.gdk-pixbuf-post-link.sh


### PR DESCRIPTION
Fixes #1

As mentioned in #1, it is now possible to add post-link and pre-unlink scripts to this feedstock (`librsvg`) that update the `gdk-pixbuf` loaders as described in conda-forge/gdk-pixbuf-feedstock#2.  This PR does so.

---

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
