### PR TITLE
Refactor meta.yaml: move gobject-introspection to build and migrate to glib 2.64.6

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -15,7 +15,7 @@ docker_image:
 gdk_pixbuf:
 - '2'
 glib:
-- '2.58'
+- 2.64.6
 libxml2:
 - '2.9'
 pango:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -19,7 +19,7 @@ docker_image:
 gdk_pixbuf:
 - '2'
 glib:
-- '2.58'
+- 2.64.6
 libxml2:
 - '2.9'
 pango:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -15,7 +15,7 @@ docker_image:
 gdk_pixbuf:
 - '2'
 glib:
-- '2.58'
+- 2.64.6
 libxml2:
 - '2.9'
 pango:

--- a/.ci_support/migrations/glib2646.yaml
+++ b/.ci_support/migrations/glib2646.yaml
@@ -1,0 +1,13 @@
+migrator_ts: 1
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+
+glib:
+  - 2.64.6
+libglib:
+  - 2.64.6

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -13,7 +13,7 @@ channel_targets:
 gdk_pixbuf:
 - '2'
 glib:
-- '2.58'
+- 2.64.6
 libxml2:
 - '2.9'
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -7,7 +7,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 gdk_pixbuf:
-- 2.38.2
+- '2'
 glib:
 - '2.58'
 libiconv:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -9,7 +9,7 @@ channel_targets:
 gdk_pixbuf:
 - '2'
 glib:
-- '2.58'
+- 2.64.6
 libiconv:
 - '1.16'
 libxml2:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jenzopr @pkgw @tschoonj
+* @pkgw @tschoonj

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@jenzopr](https://github.com/jenzopr/)
 * [@pkgw](https://github.com/pkgw/)
 * [@tschoonj](https://github.com/tschoonj/)
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,6 +6,9 @@ cd "win32"
 :: set pkg-config path so that host deps can be found
 set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig"
 
+:: set XDG_DATA_DIRS to find gir files
+set "XDG_DATA_DIRS=%XDG_DATA_DIRS%;%LIBRARY_PREFIX%\share"
+
 :: add include dirs to search path
 set "INCLUDE=%INCLUDE%;%LIBRARY_INC%\cairo;%LIBRARY_INC%\gdk-pixbuf-2.0"
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,9 +16,11 @@ set "INCLUDE=%INCLUDE%;%LIBRARY_INC%\cairo;%LIBRARY_INC%\gdk-pixbuf-2.0"
 :: (override rustup command so that the conda-forge rust installation is used)
 :: (add libiconv for linking against because glib needs its symbols)
 :: (abuse LIBINTL_LIB to add libs that are needed for linking RSVG tools)
+:: (override BINDIR to ensure the gobject-introspection tools are found)
 set ^"LIBRSVG_OPTIONS=^
   CFG=release ^
   PREFIX="%LIBRARY_PREFIX%" ^
+  BINDIR="%BUILD_PREFIX%\Library\bin" ^
   INTROSPECTION=1 ^
   RUSTUP=echo ^
   LIBINTL_LIB="intl.lib iconv.lib advapi32.lib" ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,9 +2,14 @@
 
 set -ex
 
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$BUILD_PREFIX/lib/pkgconfig
+export XDG_DATA_DIRS=${XDG_DATA_DIRS}:$PREFIX/share
+
 configure_args=(
     --prefix=$PREFIX
     --disable-Bsymbolic
+    --enable-pixbuf-loader=yes
+    --enable-introspection=yes
 )
 
 if [[ $(uname) == Darwin ]] ; then

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,2 @@
-# update gdk_pixbuf pin for windows (version from conda-forge-pinning doesn't exist)
-gdk_pixbuf:  # [win]
-  - 2.38.2  # [win]
+gdk_pixbuf:
+  - 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   build:
     - cmake  # [win]
     - make  # [unix]
+    - gobject-introspection
     - pkg-config
     - rust
     - {{ compiler('c') }}
@@ -35,7 +36,6 @@ requirements:
     - libxml2
     - cairo
     - gdk-pixbuf
-    - gobject-introspection  # [win]
     - pango
   run:
     - glib
@@ -75,6 +75,10 @@ test:
     - if not exist %PREFIX%\\Library\\include\\{{ name_abi }}\\{{ name }}\\librsvg-features.h exit 1  # [win]
     - if not exist %PREFIX%\\Library\\include\\{{ name_abi }}\\{{ name }}\\rsvg-cairo.h exit 1  # [win]
     - if not exist %PREFIX%\\Library\\include\\{{ name_abi }}\\{{ name }}\\rsvg.h exit 1  # [win]
+
+    # test for gobject-introspection files
+    - test -f $PREFIX/lib/girepository-1.0/Rsvg-2.0.typelib  # [unix]
+    - if not exist %LIBRARY_LIB%\\girepository-1.0\\Rsvg-2.0.typelib exit 1  # [win]
 
 about:
   home: https://wiki.gnome.org/Projects/LibRsvg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - add_rust_lto.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # Looks good but no new info after 2.43 so keeping it x.x for safety.
     # https://abi-laboratory.pro/?view=timeline&l=librsvg


### PR DESCRIPTION
@isuruf, this may be a better starting point for the ARM OSX migration PR.