### PR TITLE
Add if-exist guards to post-link, pre-unlink scripts

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -23,7 +23,7 @@ set ^"LIBRSVG_OPTIONS=^
   BINDIR="%BUILD_PREFIX%\Library\bin" ^
   INTROSPECTION=1 ^
   RUSTUP=echo ^
-  LIBINTL_LIB="intl.lib iconv.lib advapi32.lib" ^
+  LIBINTL_LIB="intl.lib iconv.lib advapi32.lib bcrypt.lib" ^
  ^"
 
 :: configure files

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - add_rust_lto.patch
 
 build:
-  number: 2
+  number: 3
   run_exports:
     # Looks good but no new info after 2.43 so keeping it x.x for safety.
     # https://abi-laboratory.pro/?view=timeline&l=librsvg

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,2 +1,10 @@
+set GDK_PIXBUF_POST_LINK_SCRIPT=%PREFIX%\Scripts\.gdk-pixbuf-post-link.bat
+
 :: The gdk-pixbuf post-link function updates the loaders
-call "%PREFIX%\Scripts\.gdk-pixbuf-post-link.bat"
+if exist "%GDK_PIXBUF_POST_LINK_SCRIPT%" (
+    call "%GDK_PIXBUF_POST_LINK_SCRIPT%"
+) else >> "%PREFIX%\.messages.txt" (
+    echo.librsvg: The post-link script did not complete.
+    echo.To take advantage of gdk-pixbuf's support for librsvg, please run:
+    echo.    %GDK_PIXBUF_POST_LINK_SCRIPT%
+)

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,2 +1,12 @@
-# The gdk-pixbuf post-link function updates the loaders
-${PREFIX}/bin/.gdk-pixbuf-post-link.sh
+GDK_PIXBUF_POST_LINK_SCRIPT="${PREFIX}/bin/.gdk-pixbuf-post-link.sh"
+if [ -x "$GDK_PIXBUF_POST_LINK_SCRIPT" ]
+then
+    # The gdk-pixbuf post-link function updates the loaders
+    "$GDK_PIXBUF_POST_LINK_SCRIPT"
+else
+    cat >> ${PREFIX}/.messages.txt << EOF
+librsvg: The post-link script did not complete.
+To take advantage of gdk-pixbuf's support for librsvg, please run:
+    $GDK_PIXBUF_POST_LINK_SCRIPT
+EOF
+fi

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,3 +1,6 @@
+set GDK_PIXBUF_POST_LINK_SCRIPT=%PREFIX%\Scripts\.gdk-pixbuf-post-link.bat
+if not exist "%GDK_PIXBUF_POST_LINK_SCRIPT%" exit 0
+
 :: Since librsvg is being removed, we want it to be removed from loaders.cache.
 :: But since this is a PRE-unlink script, the loader is still present.
 :: Remove it now so we can update loaders.cache correctly.
@@ -8,4 +11,4 @@ del /F /S /Q "libpixbufloader-svg.dll" > nul 2>> "%PREFIX%/.messages.txt"
 if errorlevel 1 exit 1
 
 :: The gdk-pixbuf post-link function updates the loaders
-call "%PREFIX%\Scripts\.gdk-pixbuf-post-link.bat"
+call "%GDK_PIXBUF_POST_LINK_SCRIPT%"

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,7 +1,10 @@
+GDK_PIXBUF_POST_LINK_SCRIPT="${PREFIX}/bin/.gdk-pixbuf-post-link.sh"
+if [ ! -x "$GDK_PIXBUF_POST_LINK_SCRIPT" ]; then exit 0; fi
+
 # Since librsvg is being removed, we want it to be removed from loaders.cache.
 # But since this is a PRE-unlink script, the loader is still present.
 # Remove it now so we can update loaders.cache correctly.
 rm -f ${PREFIX}/lib/gdk-pixbuf-2.0/*/loaders/libpixbufloader-svg.so
 
 # The gdk-pixbuf post-link function updates the loaders
-${PREFIX}/bin/.gdk-pixbuf-post-link.sh
+"$GDK_PIXBUF_POST_LINK_SCRIPT"


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes #90.

<!--
Please add any other relevant info below:
-->

Ensures that gdk-pixbuf's post-link script exists before calling it. If it doesn't, ask conda to print a warning message for the user.